### PR TITLE
Add in redirects to sew up loose ends

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,11 @@
+/angular-sortable-view                          http://kamilkp.github.io/angular-sortable-view/           301
+/budgeting/                                     https://budget.modus.app                                  301
 /budgeting-sample-app-webpack2                  https://budget.modus.app                                  301
-/stop-watch-box                                 https://stopwatchbox.modus.app                            301
+/Flyleaf                                        https://grgur.github.io/Flyleaf                           301
 /ion-meetups                                    https://ion-meetups.modus.app                             301
-/trackerEditor                                  https://trackeditor.modus.app                             301
 /ng-exercise                                    https://ng-exercise.modus.app                             301
 /react-dynamic-route-loading-es6                https://react-dynamic-route-loading-es6.modus.app         301
+/react-idle                                     https://react-idle.modus.app                              301
+/stop-watch-box                                 https://stopwatchbox.modus.app                            301
+/touch-node                                     https://touch-node.modus.app                              301
+/trackerEditor                                  https://trackeditor.modus.app                             301


### PR DESCRIPTION
I added in redirects to the modus.app domains for these:

https://github.com/ModusCreateOrg/react-idle/
https://github.com/ModusCreateOrg/touch-node/

These 2 are forks so I wouldn’t expect them to have gh-pages off ModusCreateOrg’s config, but they do have gh-pages off the original repos so they are in there like that for good measure:

https://github.com/ModusCreateOrg/angular-sortable-view/
https://github.com/ModusCreateOrg/Flyleaf/

The budgeting app might have been reached at https://labs.moduscreate.com/budgeting so there’s a redirect for that too now.