### PR TITLE
Allow GTM in CSP

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
             [
               `Content-Security-Policy:`,
               `default-src 'self';`,
-              `script-src 'self' data: 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com consent.cookiebot.com www.google-analytics.com consentcdn.cookiebot.com;`,
+              `script-src 'self' data: 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com tagmanager.google.com consent.cookiebot.com www.google-analytics.com consentcdn.cookiebot.com;`,
               `style-src 'self' 'unsafe-inline' fonts.googleapis.com;`,
               `img-src 'self' data: res.cloudinary.com www.google-analytics.com avatars.io www.netlify.com;`,
               `font-src fonts.gstatic.com;`,


### PR DESCRIPTION
Add tagmanger.google.com to `script-src`