### PR TITLE
rename HomeLayout to avoid duplicated classes

### DIFF
--- a/src/components/layout/Defaults/index.js
+++ b/src/components/layout/Defaults/index.js
@@ -16,7 +16,7 @@ function canUseWebP() {
   }
 }
 
-export default class HomeLayout extends React.Component {
+export default class DefaultLayout extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
   };


### PR DESCRIPTION
Fixes the duplicated HomeLayout class in the [Home](https://github.com/ModusCreateOrg/labs/blob/master/src/components/layout/Home/index.js#L10) layout and the [Default](https://github.com/ModusCreateOrg/labs/blob/master/src/components/layout/Defaults/index.js#L19) layout.