### PR TITLE
Fix multiple tags responsive problems

### DIFF
--- a/src/components/project/Listing/styles.module.scss
+++ b/src/components/project/Listing/styles.module.scss
@@ -21,6 +21,8 @@
 }
 
 .tags {
+  display: flex;
+  flex-flow: row wrap;
   color: lighten($black, 30%);
   text-transform: uppercase;
   font-size: 0.8em;


### PR DESCRIPTION
The project tags on the homepage are not responsive so a project with multiple tags such as `Constellation`  breaks the layout on mobile.