### PR TITLE
improve semantics of single project view

### DIFF
--- a/src/components/layout/ProjectLandingPage/index.js
+++ b/src/components/layout/ProjectLandingPage/index.js
@@ -8,22 +8,24 @@ import Footer from '../../Footer';
 
 import s from './styles.module.scss';
 
-export default class ProjectLandingPage extends React.Component {
-  render() {
-    return (
-      <DefaultLayout>
-        <main className={s.main}>
-          <div className={s.innerContent}>
-            <Link to="/">
-              <LogoBlack />
-            </Link>
-            {this.props.children}
-          </div>
-        </main>
-        <OnIdle syncUpdate>
-          <Footer />
-        </OnIdle>
-      </DefaultLayout>
-    );
-  }
-}
+const ProjectLandingPage = ({children}) => (
+  <DefaultLayout>
+    <main className={s.main}>
+      <div className={s.innerContent}>
+        <header>
+          <Link to="/">
+            <LogoBlack />
+          </Link>
+        </header>
+        <article>
+          {children}
+        </article>
+      </div>
+    </main>
+    <OnIdle syncUpdate>
+      <Footer />
+    </OnIdle>
+  </DefaultLayout>
+);
+
+export default ProjectLandingPage

--- a/src/components/project/DescriptionBlocks/index.js
+++ b/src/components/project/DescriptionBlocks/index.js
@@ -4,32 +4,25 @@ import Image from '../../LazyImage';
 
 const DescriptionBlocks = ({ project }) =>
   project.content ? (
-    <>
+    <section>
       {Array.from(project.content).map((block, idx) => (
-        <article key={idx}>
+        <div key={idx}>
           {block.title ? <h3 className={s.title}>{block.title}</h3> : null}
           {block.description ? (
-            <p
-              className={s.description}
-              dangerouslySetInnerHTML={{ __html: block.description }}
-            />
+            <p className={s.description} dangerouslySetInnerHTML={{ __html: block.description }} />
           ) : null}
-          <div className={s.screenshotsContainer}>
-            {block.screenshots
-              ? block.screenshots.map((shot, index) => (
-                  <div className={s.screenshots} key={`screen_${index}`}>
-                    <Image
-                      filename={shot.screen}
-                      alt={project.name}
-                      className={s.screenshotImage}
-                    />
-                  </div>
-                ))
-              : null}
-          </div>
-        </article>
+          {block.screenshots ? (
+            <div className={s.screenshotsContainer}>
+              {block.screenshots.map((shot, index) => (
+                <div className={s.screenshots} key={`screen_${index}`}>
+                  <Image filename={shot.screen} alt={project.name} className={s.screenshotImage} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
       ))}
-    </>
+    </section>
   ) : null;
 
 export default DescriptionBlocks;

--- a/src/components/project/DescriptionBlocks/styles.module.scss
+++ b/src/components/project/DescriptionBlocks/styles.module.scss
@@ -7,8 +7,7 @@ a:hover {
  * Project details content titles bold/width
  */
 .title {
-  font-weight: $title-weight;
-  margin-bottom: 1rem;
+  composes: title from global;
   margin-top: 5rem;
 }
 

--- a/src/components/project/Listing/index.js
+++ b/src/components/project/Listing/index.js
@@ -6,7 +6,7 @@ import DetailsBtn from '../DetailButton';
 import s from './styles.module.scss';
 
 const ProjectListing = ({ project, className }) => (
-  <article className={classnames(s.project, className)}>
+  <section className={classnames(s.project, className)}>
     <h2>
       <Link className={s.projectTitle} to={`/${project.route}`}>{project.name}</Link>
     </h2>
@@ -20,7 +20,7 @@ const ProjectListing = ({ project, className }) => (
       ))}
     </div>
     <DetailsBtn text="View on" href={project.repo} />
-  </article>
+  </section>
 );
 
 ProjectListing.propTypes = {

--- a/src/components/project/Overview/index.js
+++ b/src/components/project/Overview/index.js
@@ -3,13 +3,13 @@ import s from './styles.module.scss';
 
 const ProjectOverview = props => {
   return (
-    <article className={s.contentContainer}>
+    <section className={s.contentContainer}>
       <div className={s.main}>
-        <h3 className={s.titleProps}>Project Overview</h3>
+        <h3 className={s.title}>Project Overview</h3>
         <div className={s.projectDescription}>{props.project.description}</div>
       </div>
-      <aside className={s.side}>
-        <div>
+      <div className={s.side}>
+        <aside>
           <h2 className={s.subTitle}>Technology</h2>
           {props.project.stack.map((stacks, index) => (
               <span key={`teck_stacks_${index}`} className={s.technologyContent}>
@@ -17,17 +17,17 @@ const ProjectOverview = props => {
               </span>
             )
           )}
-        </div>
-        <div className={s.tagsSection}>
+        </aside>
+        <aside className={s.tagsSection}>
           <h2 className={s.subTitle}>Tags</h2>
           {props.project.tags.map((tag, index) => (
             <div className={s.tagsParent} key={`tag_index${index}`}>
               <div className={s.tagsChild}>{tag}</div>
             </div>
           ))}
-        </div>
-      </aside>
-    </article>
+        </aside>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/project/Overview/styles.module.scss
+++ b/src/components/project/Overview/styles.module.scss
@@ -18,9 +18,8 @@
 /**
  * Project details content titles bold/width
  */
-.titleProps {
-  font-weight: $title-weight;
-  margin-bottom: 1rem;
+.title {
+  composes: title from global;
 }
 
 /**

--- a/src/components/project/Summary/index.js
+++ b/src/components/project/Summary/index.js
@@ -5,16 +5,18 @@ import s from './styles.module.scss';
 
 const ProjectSummaryInfo = ({ project }) => {
   return (
-    <section className={s.header}>
+    <header className={s.header}>
       <div className={s.content}>
         <h1>{project.name}</h1>
         <h3>{project.headline}</h3>
         <ProjectDetailButtonChild text="View on" href={project.repo} />
       </div>
-      <aside className={s.image}>
-        {project['image'] ? <Image filename={project.image} alt={project.name} /> : null}
-      </aside>
-    </section>
+      {project['image'] ?
+        <div className={s.image}>
+          <Image filename={project.image} alt={project.name} />
+        </div>
+      : null}
+    </header>
   );
 };
 

--- a/src/components/project/Summary/index.js
+++ b/src/components/project/Summary/index.js
@@ -5,7 +5,7 @@ import s from './styles.module.scss';
 
 const ProjectSummaryInfo = ({ project }) => {
   return (
-    <article className={s.header}>
+    <section className={s.header}>
       <div className={s.content}>
         <h1>{project.name}</h1>
         <h3>{project.headline}</h3>
@@ -14,7 +14,7 @@ const ProjectSummaryInfo = ({ project }) => {
       <aside className={s.image}>
         {project['image'] ? <Image filename={project.image} alt={project.name} /> : null}
       </aside>
-    </article>
+    </section>
   );
 };
 

--- a/src/components/project/Team/index.js
+++ b/src/components/project/Team/index.js
@@ -3,7 +3,7 @@ import TwitterButton from '../TwitterButton';
 import s from './styles.module.scss';
 
 const Team = ({ project }) => (
-  <article>
+  <aside>
     <h3 className={s.title}>Team</h3>
     <div className={s.team}>
       {project.team.map((teamMember, index) => (
@@ -30,7 +30,7 @@ const Team = ({ project }) => (
         </div>
       ))}
     </div>
-  </article>
+  </aside>
 );
 
 export default Team;

--- a/src/containers/Projects/styles.module.scss
+++ b/src/containers/Projects/styles.module.scss
@@ -18,6 +18,7 @@
 
 .listItem {
   flex: 1 1 auto;
+  max-width: 100%;
   @media only screen and (min-width: $desktop) {
     flex: 0 0 44%;
     &:nth-child(even) {

--- a/src/theme/globals.scss
+++ b/src/theme/globals.scss
@@ -16,10 +16,9 @@ body {
   box-sizing: border-box;
 }
 
-h1, .h1 {
-  font-family: $fontAlt;
+h1,
+.h1 {
   font-size: 4.25rem;
-  font-weight: 800;
 
   @media only screen and (max-width: $desktop) {
     font-size: 3.25rem;
@@ -30,16 +29,31 @@ h1, .h1 {
   }
 }
 
-h2, .h2 {
-  font-family: $fontAlt;
+h2,
+.h2 {
   font-size: 2.75rem;
-  font-weight: 800;
 }
 
-h3, .h3 {
-  font-family: $fontAlt;
+h3,
+.h3 {
   font-size: 2.275rem;
   font-weight: 300;
+}
+
+h1,
+h2,
+h3,
+.h1,
+.h2,
+.h3 {
+  font-family: $fontAlt;
+}
+
+h1,
+h2,
+.h1,
+.h2 {
+  font-weight: 800;
 }
 
 h1,
@@ -65,4 +79,9 @@ p {
 a {
   text-decoration: none;
   color: $black;
+}
+
+.title {
+  font-weight: $title-weight;
+  margin-bottom: 1rem;
 }


### PR DESCRIPTION
So the semantics on the single project view has some problems, it's treating every section as a separate article when in fact we can use `article` as the wrapper of the whole project and rely on different tags such as sections, divs and aside to give a better meaning for the whole project content.

What changed?

- Wrapped the whole project with an `article` tag.
- Changed the Summary to a `header` tag.
- Changed the team section to an `aside` tag.
- Changed the content and project overview to `section` tag.

This makes the project page feel like a whole instead of separated parts.
